### PR TITLE
chore: update uuid. silence warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dwyl/aguid",
   "dependencies": {
-    "uuid": "^3.0.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "istanbul": "^0.4.0",


### PR DESCRIPTION
Silences warning:- 
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.